### PR TITLE
support auto fixing benchmark failures

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -2,6 +2,16 @@ cis-benchmark:
   description: |
     Run the CIS Kubernetes Benchmark against snap-based components.
   params:
+    apply:
+      type: string
+      default: ''
+      description: |
+        Apply remediations to address benchmark failures. The default, an empty
+        string, will not attempt to fix any reported failures. Set to
+        'conservative' to resolve simple failures. Set to 'dangerous' to
+        resolve all failures.
+
+        Note: Applying any remediation may result in an unusable cluster.
     config:
       type: string
       default: 'https://github.com/charmed-kubernetes/kube-bench-config/archive/master.zip#sha1=4a6f7a092ff893ab7a5e2e6596e91a7eeacdfce4'

--- a/actions/cis-benchmark
+++ b/actions/cis-benchmark
@@ -1,5 +1,6 @@
 #!/usr/local/sbin/charm-env python3
 import os
+import json
 import shlex
 import shutil
 import subprocess
@@ -19,6 +20,14 @@ BENCH_BIN = '{}/kube-bench'.format(BENCH_HOME)
 BENCH_CFG = '{}/cfg'.format(BENCH_HOME)
 GO_PKG = 'github.com/aquasecurity/kube-bench'
 RESULTS_DIR = '/home/ubuntu/kube-bench-results'
+
+# Remediation dicts associate a failing test with a command that will fix it
+CONSERVATIVE = {
+    '0.0.0': 'echo "this is fine"',
+}
+DANGEROUS = {
+    '0.0.0': 'echo "this is fine"',
+}
 
 
 def _fail(msg):
@@ -105,10 +114,45 @@ def install(release, config):
         dirpath=archive_dir, filename='config.yaml', dest=BENCH_CFG)
 
 
-def report():
+def apply(remediations=None):
+    '''Apply remediations to address benchmark failures.
+
+    :param: remediations: either 'conservative' or 'dangerous'
+    '''
+    danger = True if remediations == 'dangerous' else False
+
+    json_report = report(log_format='json')
+    hookenv.log('Loading JSON from: {}'.format(json_report))
+    try:
+        with open(json_report, 'r') as f:
+            full_json = json.load(f)
+    except Exception:
+        _fail('Failed to load: {}'.format(json_report))
+
+    for test in full_json.get('tests', {}):
+        for result in test.get('results', {}):
+            test_num = result.get('test_number')
+            test_status = result.get('status', '')
+
+            if test_status.lower() == 'fail':
+                test_remedy = CONSERVATIVE.get(test_num)
+                if not test_remedy and danger:
+                    test_remedy = DANGEROUS.get(test_num)
+                if test_remedy:
+                    hookenv.log('{} remediation is: {}'.format(test_num))
+                else:
+                    hookenv.log('{} remediation is missing'.format(test_num))
+
+
+def report(log_format='text'):
     '''Run kube-bench and report results.
 
-    Save the full results to our RESULTS_DIR and display a summary to the user.
+    By default, save the full plain-text results to our RESULTS_DIR and set
+    action output with a summary. This function can also save full results in
+    a machine-friendly json format.
+
+    :param: log_format: String determines if output is text or json
+    :returns: Path to results file
     '''
     Path(RESULTS_DIR).mkdir(parents=True, exist_ok=True)
 
@@ -126,32 +170,42 @@ def report():
     else:
         _fail('Unable to determine the node type to benchmark: {}'.format(app))
 
-    verbose_cmd = ('{bin} -D {cfg} --version {ver} {node}'.format(
-        bin=BENCH_BIN, cfg=BENCH_CFG, ver=version, node=node_type))
-    summary_cmd = ('{bin} -D {cfg} --version {ver} --noremediations {node}'.format(
-        bin=BENCH_BIN, cfg=BENCH_CFG, ver=version, node=node_type))
+    if log_format == 'json':
+        verbose_cmd = ('{bin} -D {cfg} --version {ver} --json {node}'.format(
+            bin=BENCH_BIN, cfg=BENCH_CFG, ver=version, node=node_type))
+        summary_cmd = None
+        log_prefix = 'kube-bench-json-'
+    else:
+        verbose_cmd = ('{bin} -D {cfg} --version {ver} {node}'.format(
+            bin=BENCH_BIN, cfg=BENCH_CFG, ver=version, node=node_type))
+        summary_cmd = ('{bin} -D {cfg} --version {ver} --noremediations {node}'.format(
+            bin=BENCH_BIN, cfg=BENCH_CFG, ver=version, node=node_type))
+        log_prefix = 'kube-bench-txt-'
 
-    # store full results for future operator consumption
-    with tempfile.NamedTemporaryFile(mode='w+b', prefix='kube-bench-',
+    # store full results for future consumption
+    with tempfile.NamedTemporaryFile(mode='w+b', prefix=log_prefix,
                                      dir=RESULTS_DIR, delete=False) as res_file:
         try:
             subprocess.call(shlex.split(verbose_cmd), stdout=res_file)
         except subprocess.CalledProcessError:
             _fail('Failed to run: {}'.format(verbose_cmd))
         else:
-            # send fetch command to action output
+            # remember the filename for later (and make it readable, why not?)
             Path(res_file.name).chmod(0o644)
-            fetch_cmd = 'juju scp {unit}:{file} `pwd`'.format(unit=hookenv.local_unit(),
-                                                              file=res_file.name)
-            hookenv.action_set({'cmd': verbose_cmd, 'fetch-cmd': fetch_cmd})
+            log = res_file.name
 
-    # send summary results to action output
-    try:
-        out = subprocess.check_output(shlex.split(summary_cmd), universal_newlines=True)
-    except subprocess.CalledProcessError:
-        _fail('Failed to run: {}'.format(summary_cmd))
-    else:
-        hookenv.action_set({'summary': out})
+    # machines hate summaries
+    if summary_cmd:
+        try:
+            out = subprocess.check_output(shlex.split(summary_cmd), universal_newlines=True)
+        except subprocess.CalledProcessError:
+            _fail('Failed to run: {}'.format(summary_cmd))
+        else:
+            # tell humans the command we ran as well as the summarized report
+            hookenv.action_set({'cmd': verbose_cmd, 'summary': out})
+
+    # tell whatever called us where we wrote this report
+    return log if log else ''
 
 
 if __name__ == '__main__':
@@ -167,12 +221,27 @@ if __name__ == '__main__':
     if not config:
         msg = 'Missing "config" parameter'
         _fail(msg)
+    remediations = hookenv.action_get('apply') or ''
+    if remediations not in ['', 'conservative', 'dangerous']:
+        msg = 'Invalid "apply" parameter: {}'.format(remediations)
+        _fail(msg)
 
-    # Install, report, and apply as directed
     # TODO: may want an option to overwrite an existing install
     if Path(BENCH_BIN).exists() and Path(BENCH_CFG).exists():
         hookenv.log('{} exists; skipping install'.format(BENCH_HOME))
     else:
         hookenv.log('Installing benchmark from: {}'.format(release))
         install(release, config)
-    report()
+
+    # If we have remediations to apply, do it before reporting results
+    if remediations:
+        hookenv.log('Applying "{}" remediations'.format(remediations))
+        apply(remediations)
+    else:
+        hookenv.log('Report only; no remediations were requested')
+
+    # Tell the people what they've won
+    text_report = report(log_format='text')
+    fetch_cmd = 'juju scp {unit}:{file} `pwd`'.format(unit=hookenv.local_unit(),
+                                                      file=text_report)
+    hookenv.action_set({'fetch-cmd': fetch_cmd})


### PR DESCRIPTION
- New `apply` param to choose a risk level for automatically fixing failing benchmark tests.
- Refactor `report()` to support generating machine-friendly json reports in addition to people food.
- Added `apply()` to walk the json report looking for failures; act on or log the remedy for any failing tests.