### PR TITLE
support cis-1.5

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -14,7 +14,7 @@ cis-benchmark:
         Note: Applying any remediation may result in an unusable cluster.
     config:
       type: string
-      default: 'https://github.com/charmed-kubernetes/kube-bench-config/archive/ck-1.16.zip#sha1=ea78340b12c3b01398f06dcc25b3e78724509f4d'
+      default: 'https://github.com/charmed-kubernetes/kube-bench-config/archive/cis-1.5.zip#sha1=cb8e78712ee5bfeab87d0ed7c139a83e88915530'
       description: |
         Archive containing configuration files to use when running kube-bench.
         The default value is known to be compatible with snap components. When
@@ -22,9 +22,9 @@ cis-benchmark:
         archive integrity when downloaded.
     release:
       type: string
-      default: 'upstream'
+      default: 'https://github.com/aquasecurity/kube-bench/releases/download/v0.2.3/kube-bench_0.2.3_linux_amd64.tar.gz#sha256=429a1db271689aafec009434ded1dea07a6685fee85a1deea638097c8512d548'
       description: |
-        Set the kube-bench release to run. The default value of 'upstream'
+        Set the kube-bench release to run. If set to 'upstream', the action
         will compile and use a local kube-bench binary built from the master
         branch of the upstream repository:
           https://github.com/aquasecurity/kube-bench

--- a/actions/cis-benchmark
+++ b/actions/cis-benchmark
@@ -18,7 +18,7 @@ from charms.reactive import clear_flag, is_flag_set, set_flag
 
 BENCH_HOME = '/home/ubuntu/kube-bench'
 BENCH_BIN = '{}/kube-bench'.format(BENCH_HOME)
-BENCH_CFG = '{}/cfg'.format(BENCH_HOME)
+BENCH_CFG = '{}/cfg-ck'.format(BENCH_HOME)
 GO_PKG = 'github.com/aquasecurity/kube-bench'
 RESULTS_DIR = '/home/ubuntu/kube-bench-results'
 
@@ -281,33 +281,31 @@ def report(log_format='text'):
     '''
     Path(RESULTS_DIR).mkdir(parents=True, exist_ok=True)
 
-    # Node type and config versions are different depending on the charm
+    # Node type is different depending on the charm
     app = hookenv.charm_name() or 'unknown'
+    version = 'cis-1.5'
     if 'master' in app:
-        node_type = 'master'
-        version = '1.13-snap-k8s'
+        target = 'master'
     elif 'worker' in app:
-        node_type = 'node'
-        version = '1.13-snap-k8s'
+        target = 'node'
     elif 'etcd' in app:
-        node_type = 'master'
-        version = '1.13-snap-etcd'
+        target = 'etcd'
     else:
-        _fail('Unable to determine the node type to benchmark: {}'.format(app))
+        _fail('Unable to determine the target to benchmark: {}'.format(app))
 
     # Commands and log names are different depending on the format
     if log_format == 'json':
         log_prefix = 'results-json-'
-        verbose_cmd = '{bin} -D {cfg} --version {ver} --json {node}'.format(
-            bin=BENCH_BIN, cfg=BENCH_CFG, ver=version, node=node_type)
+        verbose_cmd = '{bin} -D {cfg} --benchmark {ver} --json run --targets {target}'.format(
+            bin=BENCH_BIN, cfg=BENCH_CFG, ver=version, node=target)
     else:
         log_prefix = 'results-text-'
-        verbose_cmd = '{bin} -D {cfg} --version {ver} {node}'.format(
-            bin=BENCH_BIN, cfg=BENCH_CFG, ver=version, node=node_type)
+        verbose_cmd = '{bin} -D {cfg} --benchmark {ver} run --targets {target}'.format(
+            bin=BENCH_BIN, cfg=BENCH_CFG, ver=version, target=target)
 
-    summary_cmd = ('{bin} -D {cfg} --version {ver} '
-                   '--noremediations --noresults {node}').format(
-        bin=BENCH_BIN, cfg=BENCH_CFG, ver=version, node=node_type)
+    summary_cmd = ('{bin} -D {cfg} --benchmark {ver} '
+                   '--noremediations --noresults run --targets {target}').format(
+        bin=BENCH_BIN, cfg=BENCH_CFG, ver=version, target=target)
 
     # Store full results for future consumption
     with tempfile.NamedTemporaryFile(mode='w+b', prefix=log_prefix,

--- a/actions/cis-benchmark
+++ b/actions/cis-benchmark
@@ -296,11 +296,13 @@ def report(log_format='text'):
     # Commands and log names are different depending on the format
     if log_format == 'json':
         log_prefix = 'results-json-'
-        verbose_cmd = '{bin} -D {cfg} --benchmark {ver} --json run --targets {target}'.format(
+        verbose_cmd = ('{bin} -D {cfg} --benchmark {ver} --json run '
+                       '--targets {target}').format(
             bin=BENCH_BIN, cfg=BENCH_CFG, ver=version, node=target)
     else:
         log_prefix = 'results-text-'
-        verbose_cmd = '{bin} -D {cfg} --benchmark {ver} run --targets {target}'.format(
+        verbose_cmd = ('{bin} -D {cfg} --benchmark {ver} run '
+                       '--targets {target}').format(
             bin=BENCH_BIN, cfg=BENCH_CFG, ver=version, target=target)
 
     summary_cmd = ('{bin} -D {cfg} --benchmark {ver} '


### PR DESCRIPTION
https://bugs.launchpad.net/charm-kubernetes-master/+bug/1868183

- lock release to latest release (vs always building from upstream master)
- use cis-1.5 config by default
  - no longer need separate etcd config as 'etcd' is a valid target now
  - run kube-bench with a --benchmark version and specific targets