### PR TITLE
update readme; adjust test IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This is a base layer for common code needed to run the
 [CIS Benchmark for Kubernetes][cis-benchmark]. Charms that include this layer
-will have a `cis-benchmark` action included in their builds.
+will have a `cis-benchmark` action included in their builds. This action
+invokes the [kube-bench][kube-bench] utiity to test if Kubernetes components
+comply with the benchmark recommendations.
 
 ## Usage
 
@@ -19,15 +21,15 @@ analysis.
 
 ```yaml
 results:
-  cmd: /home/ubuntu/kube-bench/kube-bench -D /home/ubuntu/kube-bench/cfg --version
-    1.13-snap-etcd --noremediations --noresults master
+  cmd: /home/ubuntu/kube-bench/kube-bench -D /home/ubuntu/kube-bench/cfg-ck
+    --benchmark cis-1.5 --noremediations --noresults run --targets etcd
   report: juju scp etcd/0:/home/ubuntu/kube-bench-results/results-text-49681_7h .
   summary: |
     == Summary ==
     7 checks PASS
     0 checks FAIL
     0 checks WARN
-    4 checks INFO
+    0 checks INFO
 status: completed
 ```
 
@@ -51,9 +53,8 @@ snap-related components.
 
 ### release
 
-Specify the `kube-bench` release to install and run. The default value of
-`upstream` will compile and use a local kube-bench binary built from the master
-branch of the [upstream repository][kube-bench].
+Specify the `kube-bench` release to install and run. This parameter is set by
+default to a release that is known to work with snap-related components.
 
 ## Example Use Case
 
@@ -61,20 +62,20 @@ Benchmark the `kubernetes-worker` charm using a custom configuration archive:
 
 ```bash
 juju run-action --wait kubernetes-worker/0 cis-benchmark \
-  config='https://github.com/charmed-kubernetes/kube-bench-config/archive/master.zip'
+  config='https://github.com/charmed-kubernetes/kube-bench-config/archive/cis-1.5.zip'
 ```
 
 ```yaml
 results:
-  cmd: /home/ubuntu/kube-bench/kube-bench -D /home/ubuntu/kube-bench/cfg --version
-    1.13-snap-k8s --noremediations --noresults node
-  report: juju scp kubernetes-worker/0:/home/ubuntu/kube-bench-results/results-text-8c71ktcn .
+  cmd: /home/ubuntu/kube-bench/kube-bench -D /home/ubuntu/kube-bench/cfg-ck
+    --benchmark cis-1.5 --noremediations --noresults run --targets node
+  report: juju scp kubernetes-worker/0:/home/ubuntu/kube-bench-results/results-text-nmmlsvy3 .
   summary: |
     == Summary ==
     16 checks PASS
-    5 checks FAIL
-    2 checks WARN
-    1 checks INFO
+    4 checks FAIL
+    3 checks WARN
+    0 checks INFO
 status: completed
 ```
 
@@ -84,36 +85,36 @@ configuration archive:
 ```bash
 juju run-action --wait kubernetes-worker/0 cis-benchmark \
   apply='dangerous' \
-  config='https://github.com/charmed-kubernetes/kube-bench-config/archive/master.zip'
+  config='https://github.com/charmed-kubernetes/kube-bench-config/archive/cis-1.5.zip'
 ```
 
 ```yaml
 results:
-  cmd: /home/ubuntu/kube-bench/kube-bench -D /home/ubuntu/kube-bench/cfg --version
-    1.13-snap-k8s --noremediations --noresults node
-  report: juju scp kubernetes-worker/0:/home/ubuntu/kube-bench-results/results-json-7b3g6jdg .
-  summary: Applied 5 remediations. Re-run with "apply=none" to generate a new report.
+  cmd: /home/ubuntu/kube-bench/kube-bench -D /home/ubuntu/kube-bench/cfg-ck
+    --benchmark cis-1.5 --noremediations --noresults run --targets node
+  report: juju scp kubernetes-worker/0:/home/ubuntu/kube-bench-results/results-json-dozp8j3z .
+  summary: Applied 4 remediations. Re-run with "apply=none" to generate a new report.
 status: completed
 ```
 
-Re-run the initial action to see if previous failures have been fixed:
+Re-run the earlier action to verify previous failures have been fixed:
 
 ```bash
 juju run-action --wait kubernetes-worker/0 cis-benchmark \
-  config='https://github.com/charmed-kubernetes/kube-bench-config/archive/master.zip'
+  config='https://github.com/charmed-kubernetes/kube-bench-config/archive/cis-1.5.zip'
 ```
 
 ```yaml
 results:
-  cmd: /home/ubuntu/kube-bench/kube-bench -D /home/ubuntu/kube-bench/cfg --version
-    1.13-snap-k8s --noremediations --noresults node
-  report: juju scp kubernetes-worker/0:/home/ubuntu/kube-bench-results/results-text-m72vicwe .
+  cmd: /home/ubuntu/kube-bench/kube-bench -D /home/ubuntu/kube-bench/cfg-ck
+    --benchmark cis-1.5 --noremediations --noresults run --targets node
+  report: juju scp kubernetes-worker/0:/home/ubuntu/kube-bench-results/results-text-4agbktbf .
   summary: |
     == Summary ==
-    21 checks PASS
+    20 checks PASS
     0 checks FAIL
-    2 checks WARN
-    1 checks INFO
+    3 checks WARN
+    0 checks INFO
 status: completed
 ```
 

--- a/actions/cis-benchmark
+++ b/actions/cis-benchmark
@@ -28,28 +28,26 @@ RESULTS_DIR = '/home/ubuntu/kube-bench-results'
 # Tuple examples:
 #  {'1.2.3': ('manual -- we don't know how to auto fix this', None, None)}
 #  {'1.2.3': ('cli', 'command to run', None)}
-#  {'1.2.3': ('kv', 'service', {cfg_key: value}))
+#  {'1.2.3': ('kv', 'snap', {cfg_key: value})}
 CONSERVATIVE = {
     '0.0.0': ('cli', 'echo "this is fine"', None),
 
     # etcd (no known failures with a default install)
 
     # k8s-master
-    '1.1.8': ('kv', 'kube-apiserver', {'profiling': 'false'}),
-    '1.1.16': ('kv', 'kube-apiserver', {'audit-log-maxage': '30'}),
-    '1.1.17': ('kv', 'kube-apiserver', {'audit-log-maxbackup': '10'}),
-    '1.2.1': ('kv', 'kube-scheduler', {'profiling': 'false'}),
-    '1.3.1': ('kv', 'kube-controller-manager', {'terminated-pod-gc-threshold': '10'}),
+    '1.2.21': ('kv', 'kube-apiserver', {'profiling': 'false'}),
+    '1.2.23': ('kv', 'kube-apiserver', {'audit-log-maxage': '30'}),
+    '1.2.24': ('kv', 'kube-apiserver', {'audit-log-maxbackup': '10'}),
+    '1.3.1': ('kv', 'kube-controller-manager', {'terminated-pod-gc-threshold': '500'}),
     '1.3.2': ('kv', 'kube-controller-manager', {'profiling': 'false'}),
+    '1.4.1': ('kv', 'kube-scheduler', {'profiling': 'false'}),
 
     # k8s-worker
-    '2.1.2': ('kv', 'kubelet', {'authorization-mode': 'Webhook'}),
-    '2.1.4': ('kv', 'kubelet', {'read-only-port': '0'}),
-    '2.1.6': ('kv', 'kubelet', {'protect-kernel-defaults': 'true'}),
-    '2.1.9': ('kv', 'kubelet', {'event-qps': '0'}),
+    '4.2.2': ('kv', 'kubelet', {'authorization-mode': 'Webhook'}),
+    '4.2.4': ('kv', 'kubelet', {'read-only-port': '0'}),
+    '4.2.6': ('kv', 'kubelet', {'protect-kernel-defaults': 'true'}),
 }
-ADMISSION_PLUGINS = {'enable-admission-plugins': ('PersistentVolumeLabel,'
-                                                  'AlwaysPullImages,'
+ADMISSION_PLUGINS = {'enable-admission-plugins': ('PersistentVolumeLabel',
                                                   'PodSecurityPolicy,'
                                                   'ServiceAccount,'
                                                   'NodeRestriction')}
@@ -59,24 +57,22 @@ DANGEROUS = {
     # etcd (no known failures with a default install)
 
     # k8s-master
-    '1.1.1': ('kv', 'kube-apiserver', {'anonymous-auth': 'false'}),
-    '1.1.2': ('kv', 'kube-apiserver', {'basic-auth-file': None}),
-    '1.1.5': ('kv', 'kube-apiserver', {'insecure-bind-address': None}),
-    '1.1.6': ('kv', 'kube-apiserver', {'insecure-port': '0'}),
-    '1.1.11': ('kv', 'kube-apiserver', ADMISSION_PLUGINS),
-    '1.1.19': ('kv', 'kube-apiserver', {'authorization-mode': 'RBAC,Node'}),
-    '1.1.20': ('kv', 'kube-apiserver', {'token-auth-file': None}),
-    '1.1.24': ('kv', 'kube-apiserver', ADMISSION_PLUGINS),
-    '1.1.27': ('kv', 'kube-apiserver', ADMISSION_PLUGINS),
-    '1.1.32': ('kv', 'kube-apiserver', {'authorization-mode': 'RBAC,Node'}),
-    '1.1.33': ('kv', 'kube-apiserver', ADMISSION_PLUGINS),
-    '1.1.36': ('manual', None, None),
-    '1.1.39': ('kv', 'kube-apiserver', {'authorization-mode': 'RBAC,Node'}),
+    '1.2.2': ('kv', 'kube-apiserver', {'basic-auth-file': None}),
+    '1.2.3': ('kv', 'kube-apiserver', {'token-auth-file': None}),
+    '1.2.7': ('kv', 'kube-apiserver', {'authorization-mode': 'RBAC,Node'}),
+    '1.2.8': ('kv', 'kube-apiserver', {'authorization-mode': 'RBAC,Node'}),
+    '1.2.9': ('kv', 'kube-apiserver', {'authorization-mode': 'RBAC,Node'}),
+    '1.2.14': ('kv', 'kube-apiserver', ADMISSION_PLUGINS),
+    '1.2.16': ('kv', 'kube-apiserver', ADMISSION_PLUGINS),
+    '1.2.17': ('kv', 'kube-apiserver', ADMISSION_PLUGINS),
+    '1.2.18': ('kv', 'kube-apiserver', {'insecure-bind-address': None}),
+    '1.2.19': ('kv', 'kube-apiserver', {'insecure-port': '0'}),
+    '1.2.33': ('manual', None, None),
     '1.3.6': ('kv', 'kube-controller-manager',
               {'feature-gates': 'RotateKubeletServerCertificate=true'}),
 
     # k8s-worker
-    '2.1.13': ('kv', 'kubelet',
+    '4.2.12': ('kv', 'kubelet',
                {'feature-gates': 'RotateKubeletServerCertificate=true'}),
 }
 
@@ -298,7 +294,7 @@ def report(log_format='text'):
         log_prefix = 'results-json-'
         verbose_cmd = ('{bin} -D {cfg} --benchmark {ver} --json run '
                        '--targets {target}').format(
-            bin=BENCH_BIN, cfg=BENCH_CFG, ver=version, node=target)
+            bin=BENCH_BIN, cfg=BENCH_CFG, ver=version, target=target)
     else:
         log_prefix = 'results-text-'
         verbose_cmd = ('{bin} -D {cfg} --benchmark {ver} run '


### PR DESCRIPTION
Follow-up to #2 to fix:

https://bugs.launchpad.net/charm-kubernetes-master/+bug/1868183

- Update the README with cis-1.5 examples
- Update the test IDs in our remediation dicts to match cis-1.5 tests. Without this, auto remediation would look successful, but wouldn't actually do anything because a failing cis-1.5 test ID didn't necessarily match one of the keys in our dicts.

Confirmed running on k8s charms with this does indeed fix the failures when applying remediations. Before remediation, we had 18 master failures and 4 worker failures:
```bash
$ juju run-action --wait kubernetes-master/0 cis-benchmark apply=conservative
unit-kubernetes-master-0:
  UnitId: kubernetes-master/0
  id: 1da73766-953c-41fe-86d2-afaf76f8730a
  results:
    cmd: /home/ubuntu/kube-bench/kube-bench -D /home/ubuntu/kube-bench/cfg-ck --benchmark
      cis-1.5 --noremediations --noresults run --targets master
    report: juju scp kubernetes-master/0:/home/ubuntu/kube-bench-results/results-json-61ywe7q7
      .
    summary: Applied 6 remediations. Re-run with "apply=none" to generate a new report.
  status: completed

$ juju run-action --wait kubernetes-worker/0 cis-benchmark apply=conservative
unit-kubernetes-worker-0:
  UnitId: kubernetes-worker/0
  id: 098fa71c-e94f-4a74-8050-320798272a86
  results:
    cmd: /home/ubuntu/kube-bench/kube-bench -D /home/ubuntu/kube-bench/cfg-ck --benchmark
      cis-1.5 --noremediations --noresults run --targets node
    report: juju scp kubernetes-worker/0:/home/ubuntu/kube-bench-results/results-json-haoy9h5w
      .
    summary: Applied 3 remediations. Re-run with "apply=none" to generate a new report.
  status: completed
```

Notice a follow-up run has 6 and 3 fewer failures, respectively:
```bash
$ juju run-action --wait kubernetes-master/0 cis-benchmark apply=none
unit-kubernetes-master-0:
  UnitId: kubernetes-master/0
  id: 01e5f253-8cbb-4e92-87c7-2fd9622e7603
  results:
    cmd: /home/ubuntu/kube-bench/kube-bench -D /home/ubuntu/kube-bench/cfg-ck --benchmark
      cis-1.5 --noremediations --noresults run --targets master
    report: juju scp kubernetes-master/0:/home/ubuntu/kube-bench-results/results-text-c1l1jpt_
      .
    summary: |
      == Summary ==
      32 checks PASS
      12 checks FAIL
      11 checks WARN
      10 checks INFO
  status: completed

$ juju run-action --wait kubernetes-worker/0 cis-benchmark apply=none
unit-kubernetes-worker-0:
  UnitId: kubernetes-worker/0
  id: 4d002a8f-2d85-42ad-8d82-1ec34476e5da
  results:
    cmd: /home/ubuntu/kube-bench/kube-bench -D /home/ubuntu/kube-bench/cfg-ck --benchmark
      cis-1.5 --noremediations --noresults run --targets node
    report: juju scp kubernetes-worker/0:/home/ubuntu/kube-bench-results/results-text-rdmpmytu
      .
    summary: |
      == Summary ==
      19 checks PASS
      1 checks FAIL
      3 checks WARN
      0 checks INFO
  status: completed
```