### PR TITLE
set new config and release defaults; tweak release description

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -14,7 +14,7 @@ cis-benchmark:
         Note: Applying any remediation may result in an unusable cluster.
     config:
       type: string
-      default: 'https://github.com/charmed-kubernetes/kube-bench-config/archive/cis-1.5.zip#sha1=cb8e78712ee5bfeab87d0ed7c139a83e88915530'
+      default: 'https://github.com/charmed-kubernetes/kube-bench-config/archive/cis-1.5.zip#sha1=811f21dbf6c841bafdbfbd8a21f912ad67582f46'
       description: |
         Archive containing configuration files to use when running kube-bench.
         The default value is known to be compatible with snap components. When
@@ -22,13 +22,15 @@ cis-benchmark:
         archive integrity when downloaded.
     release:
       type: string
-      default: 'https://github.com/aquasecurity/kube-bench/releases/download/v0.2.3/kube-bench_0.2.3_linux_amd64.tar.gz#sha256=429a1db271689aafec009434ded1dea07a6685fee85a1deea638097c8512d548'
+      default: 'https://github.com/aquasecurity/kube-bench/releases/download/v0.3.1/kube-bench_0.3.1_linux_amd64.tar.gz#sha256=6616f1373987259285e2f676a225d4a3885cd62b7e7a116102ff2fb445724281'
       description: |
-        Set the kube-bench release to run. If set to 'upstream', the action
-        will compile and use a local kube-bench binary built from the master
-        branch of the upstream repository:
+        Archive containing the 'kube-bench' binary to run. The default value
+        points to a stable upstream release. When using a custom URL, append
+        '#<hash_type>=<checksum>' to verify the archive integrity when
+        downloaded.
+
+        This may also be set to the special keyword 'upstream'. In this case,
+        the action will compile and use a local kube-bench binary built from
+        the master branch of the upstream repository:
           https://github.com/aquasecurity/kube-bench
 
-        This value may also be set to an accessible archive containing a
-        pre-built kube-bench binary, for example:
-          https://github.com/aquasecurity/kube-bench/releases/download/v0.0.34/kube-bench_0.0.34_linux_amd64.tar.gz#sha256=f96d1fcfb84b18324f1299db074d41ef324a25be5b944e79619ad1a079fca077


### PR DESCRIPTION
Partial fix for https://bugs.launchpad.net/charm-kubernetes-master/+bug/1887693

With https://github.com/charmed-kubernetes/kube-bench-config/pull/2 merged, it's time to set our default action params to use the updated configs and latest kube-bench release.

Tested local builds of etcd, k8s-master, and k8s-worker with this change and all worked as expected.